### PR TITLE
Introduce noprep variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  test:
+    name: OTP ${{matrix.otp}}
+    strategy:
+      matrix:
+        otp: ['23.2', '22.3.4.9', '21.3.8.9']
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ErlGang/setup-erlang@v1.0.0
+        with:
+          otp-version: ${{ matrix.otp }}
+      - run: make
+      - run: make test-compile
+      - run: pip install --user codecov
+      - run: echo "/home/runner/.local/bin" >> $GITHUB_PATH
+      - run: make test
+      - run: make dialyzer
+      - run: make codecov
+      - run: codecov

--- a/rebar.config
+++ b/rebar.config
@@ -2,10 +2,10 @@
 
 {deps,
  [
-  {stringprep, {git, "https://github.com/processone/stringprep.git", {tag, "1.0.22"}}}
+  {stringprep, "1.0.24"}
  ]}.
 
-{plugins, [pc]}.
+{plugins, [pc, rebar3_hex]}.
 
 {artifacts, ["priv/jid.so"]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,8 @@
 {"1.1.0",
-[{<<"p1_utils">>,{pkg,<<"p1_utils">>,<<"1.0.18">>},1},
- {<<"stringprep">>,
-  {git,"https://github.com/processone/stringprep.git",
-       {ref,"0f0df1b10aac78cbe6088b142d172de43fc387a3"}},
-  0}]}.
+[{<<"p1_utils">>,{pkg,<<"p1_utils">>,<<"1.0.21">>},1},
+ {<<"stringprep">>,{pkg,<<"stringprep">>,<<"1.0.24">>},0}]}.
 [
 {pkg_hash,[
- {<<"p1_utils">>, <<"3FE224DE5B2E190D730A3C5DA9D6E8540C96484CF4B4692921D1E28F0C32B01C">>}]}
+ {<<"p1_utils">>, <<"9D6244BBD4AF881E85AF71655E8BE5720B5B965B1BDD51A35C7871FD4142AF9A">>},
+ {<<"stringprep">>, <<"5A2C29785CDC1EADDCBA0564CD86020E5E686FE9E66FA47A80A97333F3DC75EA">>}]}
 ].

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -23,6 +23,7 @@
 -export([are_equal/2]).
 -export([are_bare_equal/2]).
 -export([from_binary/1]).
+-export([from_binary_noprep/1]).
 -export([to_binary/1]).
 -export([is_nodename/1]).
 -export([nodeprep/1]).
@@ -32,6 +33,7 @@
 -export([to_lus/1]).
 -export([to_bare/1]).
 -export([replace_resource/2]).
+-export([replace_resource_noprep/2]).
 -export([binary_to_bare/1]).
 -export([str_tolower/1]).
 
@@ -133,6 +135,17 @@ from_binary(J) when is_binary(J), byte_size(J) < ?XMPP_JID_SIZE_LIMIT ->
 from_binary(_) ->
     error.
 
+-spec from_binary_noprep(binary()) -> jid() | error.
+from_binary_noprep(J) when is_binary(J), byte_size(J) < ?XMPP_JID_SIZE_LIMIT ->
+    case from_binary_nif(J) of
+        {U, S, R} ->
+            #jid{user = U, server = S, resource = R,
+                 luser = U, lserver = S, lresource = R};
+        error -> error
+    end;
+from_binary_noprep(_) ->
+    error.
+
 %% Original Erlang equivalent can be found in test/jid_SUITE.erl,
 %% together with `proper` generators to check for equivalence
 -spec from_binary_nif(binary()) -> simple_jid() | error.
@@ -215,6 +228,10 @@ replace_resource(#jid{} = JID, Resource) ->
         LResource ->
             JID#jid{resource = Resource, lresource = LResource}
     end.
+
+-spec replace_resource_noprep(jid(), resource()) -> jid() | error.
+replace_resource_noprep(#jid{} = JID, LResource) ->
+    JID#jid{resource = LResource, lresource = LResource}.
 
 -spec binary_to_bare(binary()) -> jid() | error.
 binary_to_bare(JID) when is_binary(JID) ->

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -11,12 +11,15 @@
          binary_to_jid_succeeds_with_valid_binaries/1,
          binary_to_jid_fails_with_invalid_binaries/1,
          binary_to_jid_fails_with_empty_binary/1,
+         binary_noprep_to_jid_succeeds_with_valid_binaries/1,
+         binary_noprep_to_jid_fails_with_empty_binary/1,
          make_jid_fails_on_binaries_that_are_too_long/1,
          make_is_independent_of_the_input_format/1,
          make_noprep_and_make_have_equal_raw_jid/1,
          make_noprep_is_independent_of_the_input_format/1,
          jid_to_lower_fails_if_any_binary_is_invalid/1,
          jid_replace_resource_failes_for_invalid_resource/1,
+         jid_replace_resource_noprep_failes_for_invalid_resource/1,
          nodeprep_fails_with_too_long_username/1,
          nameprep_fails_with_too_long_domain/1,
          resourceprep_fails_with_too_long_resource/1,
@@ -50,12 +53,15 @@ groups() ->
                            binary_to_jid_succeeds_with_valid_binaries,
                            binary_to_jid_fails_with_invalid_binaries,
                            binary_to_jid_fails_with_empty_binary,
+                           binary_noprep_to_jid_succeeds_with_valid_binaries,
+                           binary_noprep_to_jid_fails_with_empty_binary,
                            make_jid_fails_on_binaries_that_are_too_long,
                            make_is_independent_of_the_input_format,
                            make_noprep_and_make_have_equal_raw_jid,
                            make_noprep_is_independent_of_the_input_format,
                            jid_to_lower_fails_if_any_binary_is_invalid,
                            jid_replace_resource_failes_for_invalid_resource,
+                           jid_replace_resource_noprep_failes_for_invalid_resource,
                            nodeprep_fails_with_too_long_username,
                            nameprep_fails_with_too_long_domain,
                            resourceprep_fails_with_too_long_resource,
@@ -96,6 +102,14 @@ binary_to_jid_fails_with_invalid_binaries(_C) ->
     run_property(Prop, 200, 1, 100).
 
 binary_to_jid_fails_with_empty_binary(_) ->
+    error = jid:from_binary(<<>>).
+
+binary_noprep_to_jid_succeeds_with_valid_binaries(_) ->
+    Prop = ?FORALL(BinJid, (jid_gen:jid()),
+                   (is_record(jid:from_binary_noprep(BinJid), jid))),
+    run_property(Prop, 200, 1, 100).
+
+binary_noprep_to_jid_fails_with_empty_binary(_) ->
     error = jid:from_binary(<<>>).
 
 make_jid_fails_on_binaries_that_are_too_long(_) ->
@@ -175,6 +189,17 @@ jid_replace_resource_failes_for_invalid_resource(_) ->
                    {jid_gen:bare_jid(), jid_gen:maybe_valid_resource()},
                    jid_replace_resource(BinJid, MaybeCorrectRes)),
     run_property(Prop, 100, 1, 42).
+
+jid_replace_resource_noprep_failes_for_invalid_resource(_) ->
+    Prop = ?FORALL({BinJid, MaybeCorrectRes},
+                   {jid_gen:bare_jid(), jid_gen:resource()},
+                   jid_replace_resource_noprep(BinJid, MaybeCorrectRes)),
+    run_property(Prop, 100, 1, 42).
+
+jid_replace_resource_noprep(BinJid, Res) ->
+    Jid = jid:from_binary(BinJid),
+    Jid2 = jid:replace_resource_noprep(Jid, Res),
+    check_jid_replace_resource_output(Res, Jid2).
 
 jid_replace_resource(BinJid, Res) ->
     Jid = jid:from_binary(BinJid),


### PR DESCRIPTION
Sometimes we can be sure that a binary has already been stringprepped, like when storing a stringprepped version of it on a cache or on a database and then retrieving it, we can skip stringprepping it again.

I also here update the stringprep package, and introduce github actions to its testing and removed travis jobs.