### PR TITLE
Simplify the jid data structure

### DIFF
--- a/include/jid.hrl
+++ b/include/jid.hrl
@@ -1,7 +1,4 @@
--record(jid, {user = <<>>      :: jid:user(),
-              server = <<>>    :: jid:server(),
-              resource = <<>>  :: jid:resource(),
-              luser = <<>>     :: jid:luser(),
+-record(jid, {luser = <<>>     :: jid:luser(),
               lserver = <<>>   :: jid:lserver(),
               lresource = <<>> :: jid:lresource()
              }).

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -16,26 +16,13 @@
 -module(jid).
 -on_load(load/0).
 
--export([make/3]).
--export([make/1]).
--export([make_bare/2]).
--export([make_noprep/3]).
--export([make_noprep/1]).
--export([are_equal/2]).
--export([are_bare_equal/2]).
--export([from_binary/1]).
--export([from_binary_noprep/1]).
--export([to_binary/1]).
--export([is_nodename/1]).
--export([nodeprep/1]).
--export([nameprep/1]).
--export([resourceprep/1]).
--export([to_lower/1]).
--export([to_lus/1]).
--export([to_bare/1]).
--export([replace_resource/2]).
--export([replace_resource_noprep/2]).
--export([binary_to_bare/1]).
+-export([make/3, make/1, make_bare/2, make_noprep/3, make_noprep/1]).
+-export([from_binary/1, from_binary_noprep/1]).
+-export([binary_to_bare/1, to_bare_binary/1, to_binary/1]).
+-export([are_equal/2, are_bare_equal/2, is_nodename/1]).
+-export([nodeprep/1, nameprep/1, resourceprep/1]).
+-export([to_lower/1, to_lus/1, to_bare/1]).
+-export([replace_resource/2, replace_resource_noprep/2]).
 -export([str_tolower/1]).
 
 -include("jid.hrl").
@@ -179,6 +166,18 @@ to_binary(#jid{luser = LUser, lserver = LServer, lresource = LResource}) ->
     to_binary({LUser, LServer, LResource});
 to_binary(Jid) when is_binary(Jid) ->
     Jid.
+
+-spec to_bare_binary(simple_jid() | simple_bare_jid() | jid() | literal_jid()) -> binary() | error.
+to_bare_binary({<<>>, Server}) ->
+    <<Server/binary>>;
+to_bare_binary({User, Server}) ->
+    <<User/binary, "@", Server/binary>>;
+to_bare_binary({User, Server, _}) ->
+    to_bare_binary({User, Server});
+to_bare_binary(#jid{luser = LUser, lserver = LServer}) ->
+    to_bare_binary({LUser, LServer});
+to_bare_binary(Jid) when is_binary(Jid) ->
+    binary_to_bare(Jid).
 
 %% @doc Returns true if the input is a valid user part
 -spec is_nodename(<<>> | binary()) -> boolean().

--- a/src/jid.erl
+++ b/src/jid.erl
@@ -75,10 +75,7 @@ make(User, Server, Res) ->
         {_, error, _} -> error;
         {_, _, error} -> error;
         {LUser, LServer, LRes} ->
-            #jid{user = User,
-                 server = Server,
-                 resource = Res,
-                 luser = LUser,
+            #jid{luser = LUser,
                  lserver = LServer,
                  lresource = LRes}
     end.
@@ -95,10 +92,7 @@ make_bare(User, Server) ->
         {error, _} -> error;
         {_, error} -> error;
         {LUser, LServer} ->
-            #jid{user = User,
-                 server = Server,
-                 resource = <<>>,
-                 luser = LUser,
+            #jid{luser = LUser,
                  lserver = LServer,
                  lresource = <<>>}
     end.
@@ -108,10 +102,7 @@ make_bare(User, Server) ->
                   Server   :: lserver(),
                   Resource :: lresource()) -> jid().
 make_noprep(LUser, LServer, LResource) ->
-    #jid{user = LUser,
-         server = LServer,
-         resource = LResource,
-         luser = LUser,
+    #jid{luser = LUser,
          lserver = LServer,
          lresource = LResource}.
 
@@ -157,8 +148,7 @@ from_binary(_) ->
 from_binary_noprep(J) when is_binary(J), byte_size(J) < ?XMPP_JID_SIZE_LIMIT ->
     case from_binary_nif(J) of
         {U, S, R} ->
-            #jid{user = U, server = S, resource = R,
-                 luser = U, lserver = S, lresource = R};
+            #jid{luser = U, lserver = S, lresource = R};
         error -> error
     end;
 from_binary_noprep(_) ->
@@ -185,8 +175,8 @@ to_binary({<<>>, Server}) ->
     <<Server/binary>>;
 to_binary({Node, Server}) ->
     <<Node/binary, "@", Server/binary>>;
-to_binary(#jid{user = User, server = Server, resource = Resource}) ->
-    to_binary({User, Server, Resource});
+to_binary(#jid{luser = LUser, lserver = LServer, lresource = LResource}) ->
+    to_binary({LUser, LServer, LResource});
 to_binary(Jid) when is_binary(Jid) ->
     Jid.
 
@@ -256,7 +246,7 @@ to_lus(error) ->
              (jid()) -> jid();
              (error) -> error.
 to_bare(#jid{} = JID) ->
-    JID#jid{resource = <<>>, lresource = <<>>};
+    JID#jid{lresource = <<>>};
 to_bare({U, S, _R}) ->
     {U, S, <<>>};
 to_bare(error) ->
@@ -268,13 +258,13 @@ replace_resource(#jid{} = JID, Resource) ->
     case resourceprep(Resource) of
         error -> error;
         LResource ->
-            JID#jid{resource = Resource, lresource = LResource}
+            JID#jid{lresource = LResource}
     end.
 
 %% @doc Replaces the resource part of a jid with a new resource, but without normalisation
 -spec replace_resource_noprep(jid(), resource()) -> jid().
 replace_resource_noprep(#jid{} = JID, LResource) ->
-    JID#jid{resource = LResource, lresource = LResource}.
+    JID#jid{lresource = LResource}.
 
 %% @equiv jid:to_bare(jid:from_binary(BinaryJid))
 -spec binary_to_bare(binary()) -> jid() | error.

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -23,7 +23,6 @@ groups() ->
                            binary_noprep_to_jid_fails_with_empty_binary,
                            make_jid_fails_on_binaries_that_are_too_long,
                            make_is_independent_of_the_input_format,
-                           make_noprep_and_make_have_equal_raw_jid,
                            make_noprep_is_independent_of_the_input_format,
                            jid_to_lower_fails_if_any_binary_is_invalid,
                            jid_replace_resource_failes_for_invalid_resource,
@@ -97,18 +96,6 @@ make_is_independent_of_the_input_format(_) ->
                    {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
                    jid:make(U,S,R) == jid:make({U,S,R})),
     run_property(Prop, 100, 1, 500).
-
-make_noprep_and_make_have_equal_raw_jid(_) ->
-    Prop = ?FORALL({U, S, R},
-                   {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
-                   begin
-                       #jid{user = U, server = S, resource = R} = jid:make(U, S, R),
-                       #jid{user = U, server = S, resource = R} = jid:make_noprep(U, S, R),
-                       true
-                   end
-                  ),
-    run_property(Prop, 10, 1, 500).
-
 
 make_noprep_is_independent_of_the_input_format(_) ->
     Prop = ?FORALL({U, S, R},
@@ -330,7 +317,7 @@ binary_to_jid3(<<>>, N, S, R) ->
 to_binary(Jid) when is_binary(Jid) ->
     % sometimes it is used to format error messages
     Jid;
-to_binary(#jid{user = User, server = Server, resource = Resource}) ->
+to_binary(#jid{luser = User, lserver = Server, lresource = Resource}) ->
     to_binary({User, Server, Resource});
 to_binary({User, Server}) ->
     to_binary({User, Server, <<>>});

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -39,6 +39,7 @@ groups() ->
                            compare_bare_jids_doesnt_depend_on_the_order,
                            compare_bare_with_jids_structs_and_bare_jids,
                            binary_to_bare_equals_binary_and_then_bare,
+                           to_bare_binary_equals_to_bare_then_to_binary,
                            to_lower_to_bare_equals_to_bare_to_lower,
                            make_to_lus_equals_to_lower_to_lus,
                            make_bare_like_make_with_empty_resource
@@ -231,6 +232,11 @@ compare_bare_jids(_) ->
 binary_to_bare_equals_binary_and_then_bare(_) ->
     Prop = ?FORALL(A, jid_gen:maybe_valid_jid(),
                    equals(jid:to_bare(jid:from_binary(A)), jid:binary_to_bare(A))),
+    run_property(Prop, 200, 1, 100).
+
+to_bare_binary_equals_to_bare_then_to_binary(_) ->
+    Prop = ?FORALL(A, jid_gen:jid_struct(),
+                   equals(jid:to_binary(jid:to_bare(A)), jid:to_bare_binary(A))),
     run_property(Prop, 200, 1, 100).
 
 to_lower_to_bare_equals_to_bare_to_lower(_) ->

--- a/test/jid_gen.erl
+++ b/test/jid_gen.erl
@@ -23,15 +23,14 @@
 
 jid_struct() ->
     ?LET({U, S, R}, {username(), domain(), resource()},
-         {jid, U, S, R, U, S, R}).
+         {jid, U, S, R}).
 
 from_jid() ->
     oneof([
             {jid_gen:username(), jid_gen:domain(), jid_gen:resource()},
             {<<>>, jid_gen:domain(), jid_gen:resource()},
             {jid_gen:username(), jid_gen:domain()},
-            {jid, jid_gen:username(), jid_gen:domain(), jid_gen:resource(),
-                  jid_gen:username(), jid_gen:domain(), jid_gen:resource()}
+            {jid, jid_gen:username(), jid_gen:domain(), jid_gen:resource()}
           ]).
 
 jid() ->


### PR DESCRIPTION
Remove fields that should actually never be used. The idea is that the
non-normalised parts MUST actually have never been used for comparison,
and are therefore not really needed. If only for printing and using them
in the `to` and `from` attributes of a stanza, clients SHOULD also
stringprep anyway, so the fact that the server might provide
non-normalised strings might be a problem for clients who're not
enforced to normalise them.

I've also been verifying how many other XMPP implementations tackle this
issue, and I've seen many other servers, and also a bunch of client
frameworks, simply capturing the parts and normalising them, and
building data structures that keep only their normalised pieces.

Note, I imagine this to make for a version 2.0, as it contains kinda breaking changes. Libraries shouldn't be looking into the data structure and should use the data setters and getters exposed by the API, but well, everywhere there's pattern-matching against the jid record.

---
Also interesting, using uuids for all three parts of the jid:

| Name           | ips        | average  | deviation         | median         | 99th % |
|---|---|---|---|---|---|
| master         | 5.02 M      | 199.21 ns | ±16496.03%         | 125 ns         | 985 ns |
| this-PR         | 7.01 M      | 142.69 ns | ±24749.32%         | 106 ns         | 169 ns |


| Name    | Memory usage |
|---|---|
| master            | 216 B |
| this-PR            | 192 B |