### PR TITLE
Validate domainpart against RFC

### DIFF
--- a/src/jid.erl
+++ b/src/jid.erl
@@ -214,6 +214,8 @@ lresource({_, _}) ->
 
 %% @doc Prepares the server part of a jid
 -spec nameprep(server()) -> lserver() | error.
+nameprep(<<>>) ->
+    error;
 nameprep(S) when is_binary(S), byte_size(S) < ?SANE_LIMIT ->
     R = stringprep:nameprep(S),
     validate_binary_size(R);

--- a/test/jid_SUITE.erl
+++ b/test/jid_SUITE.erl
@@ -43,6 +43,9 @@ groups() ->
                            to_lower_to_bare_equals_to_bare_to_lower,
                            make_to_lus_equals_to_lower_to_lus,
                            make_bare_like_make_with_empty_resource,
+                           make_empty_domain,
+                           make_bare_empty_domain,
+                           make_noprep_empty_domain,
                            getters_equal_struct_lookup
                           ]},
      {old_comparison, [parallel], [
@@ -264,6 +267,19 @@ make_bare_like_make_with_empty_resource(_) ->
                           jid:make(U, S, <<>>))),
     run_property(Prop, 200, 1, 100).
 
+make_empty_domain(_) ->
+    ?assertEqual(error, jid:make(jid_gen:username(), <<>>, jid_gen:resource())),
+    ?assertEqual(error, jid:make({jid_gen:username(), <<>>, jid_gen:resource()})).
+
+make_bare_empty_domain(_) ->
+    ?assertEqual(error, jid:make_bare(jid_gen:username(), <<>>)).
+
+make_noprep_empty_domain(_) ->
+    Prop = ?FORALL({U, S, R},
+                   {jid_gen:username(), <<>>, jid_gen:resource()},
+                    jid:make_noprep(U, S, R) == jid:make_noprep({U, S, R})),
+    run_property(Prop, 10, 1, 500).
+
 getters_equal_struct_lookup(_) ->
     Jid = jid:from_binary(<<"alice@localhost/res1">>),
     ?assertEqual(jid:luser(Jid), Jid#jid.luser),
@@ -277,7 +293,6 @@ getters_equal_struct_lookup(_) ->
     ?assertEqual(jid:luser(US), Jid#jid.luser),
     ?assertEqual(jid:lserver(US), Jid#jid.lserver),
     ?assertEqual(jid:lresource(US), <<>>).
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Original code kept for documentation purposes


### PR DESCRIPTION
According to RFC-7622, the domainpart must comply to the following statement:

> After any and all normalization, conversion, and mapping of code
> points as well as encoding of the string as UTF-8, a domainpart MUST
> NOT be zero octets in length and MUST NOT be more than 1023 octets in
> length.  (Naturally, the length limits of [[RFC1034](https://www.rfc-editor.org/rfc/rfc1034)] apply, and
> nothing in this document is to be interpreted as overriding those
> more fundamental limits.)

In a short brief, it means that the domainpart cannot be an empty string.